### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/devcontainers/base:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "WATcher Ubuntu DevBox",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "ubuntu-22.04"
+		}
+	},
+	"features": {
+		"git": "latest",
+		"node": "lts",
+		"ghcr.io/meaningful-ooo/devcontainer-features/fish": "latest"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8080],
+
+	//Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install -g markbind-cli",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": ["esbenp.prettier-vscode", "yzhang.markdown-all-in-one"],
+			"settings": {
+				"editor.formatOnSave": true
+			}
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
### Summary:
Fixes #8

### Changes Made:
* Added Dev Container support to WATcher documentation
* Container is with Ubuntu, fish and node

### Proposed Commit Message:
```
Add Dev Container support to WATcher documentation

For more seamless onboarding and developer setup, 
there should be dev container support for the documentation.

Let's add dev container setup for the WATcher documentation.
```
