### PR TITLE
Add API testing section to include Postman documentation

### DIFF
--- a/_markbind/layouts/dg-sitenav.md
+++ b/_markbind/layouts/dg-sitenav.md
@@ -6,6 +6,7 @@
 * [Design]({{ baseUrl }}/dg/design.html)
 * [Dev workflow]({{ baseUrl }}/dg/dev-workflow.html)
 * [Testing]({{ baseUrl }}/dg/testing.html)
+* [API Testing]({{ baseUrl }}/dg/api-testing.html)
 * [Project management]({{ baseUrl }}/dg/project-management.html)
 * [Future directions]({{ baseUrl }}/dg/future-directions.html)
 </site-nav>

--- a/dg/api-testing.md
+++ b/dg/api-testing.md
@@ -87,9 +87,9 @@ It would be quicker to duplicate an existing query as the authorization and sche
 </box>
 
 1. Add a new GraphQL query in the WATcher collection
-2. In the `Authorization` tab select `Basic Auth` as the Auth Type
-3. Use `{{username}}` and `{{token}}` in the username and password field respectively. This uses the variables in your environment
-4. In the `Query` tab, you will be able to import your schema, add your query and the relevant variables
+1. In the `Authorization` tab select `Basic Auth` as the Auth Type
+1. Use `{{ '{{' }}username{{ '}}' }}` and `{{ '{{' }}token{{ '}}' }}` in the username and password field respectively. This uses the variables in your environment
+1. In the `Query` tab, you will be able to import your schema, add your query and the relevant variables
 
 # Testing Queries
 1. In the `Query` tab, the arguments used for the select query can be changed in the `Variables` section.

--- a/dg/api-testing.md
+++ b/dg/api-testing.md
@@ -1,0 +1,97 @@
+<frontmatter>
+  header: header.md
+  title: "DG: API Testing"
+  pageNav: 2
+  siteNav: dg-nav.md
+  footer: footer.md
+</frontmatter>
+
+# API Testing
+
+This page contains information useful for testing and creation of queries used in WATcher.
+
+-------------------------------------------------------------------------------------
+
+# Postman Set Up
+
+[Workspace can be found here!](https://www.postman.com/orange-station-77364/watcher/overview)
+
+## Getting Started
+
+**Prerequisites:**
+* [Postman](https://www.postman.com/) account
+* [GitHub token](https://www.postman.com/) -- visit the link to learn how to get your token
+
+**Steps**
+
+<box type="tip" seamless>
+
+All the following actions are done in Postman.
+</box>
+
+1. Create an empty workspace to fork to
+1. Fork this [collection](https://www.postman.com/orange-station-77364/watcher/collection/67d861f681942940507d4259) to your workspace using the fork button at the top right corner
+1. Create a file `schema.graphql` on your local machine
+1. Paste the following schema and save
+    ```
+    type Issue {
+      id: ID!
+      number: Int!
+      title: String!
+      body: String
+      state: String!
+      createdAt: String!
+      updatedAt: String!
+      url: String!
+      isDraft: Boolean  # Your custom extension
+    }
+    ```
+1. Select any query
+1. Click on the `Schema` tab
+1. Click on `Import a GraphQL schema`
+1. Select `schema.graphql` file on your local machine
+1. Click on `Import as API` to save it online
+
+## Environment Variables
+
+<box type="tip" seamless>
+
+The environment section is used to store sensitive data which are only meant for yourself. An example of sensitive data will be your GitHub token.
+</box>
+
+1. Create a new environment by clicking on the dropdown that says `No environment` at the top right corner
+1. Click on the + button
+1. Add the following variables
+   | Variable | Type | Initial value | Current value |
+   |----------|------|---------------|---------------|
+   | username | default | <YOUR_GITHUB_USERNAME> | <YOUR_GITHUB_USERNAME> |
+   | token    | secret  | <YOUR_GITHUB_TOKEN> | <YOUR_GITHUB_TOKEN> |
+
+# Understanding Queries
+
+The queries used in WATcher are created with the use of fragment queries. Fragment query is a reusable unit that allows you to define parts of a query and use them in multiple places. This can be found in `graphql > fragments` in WATcher and in the `Fragments` folder in Postman.
+
+Due to limitations in Postman, any fragments used should be added to the query section as well.
+
+### Cursor
+
+In some queries, you will see a cursor argument. The cursor is mainly used for the pagination of queries.
+* The initial value starts with `null`
+* Each query will generate a cursor which you will need to include as an argument for the the next query
+
+# Creating A New Query
+<box type="tip" seamless>
+
+It would be quicker to duplicate an existing query as the authorization and schema will be copied as well.
+
+</box>
+
+1. Add a new GraphQL query in the WATcher collection
+2. In the `Authorization` tab select `Basic Auth` as the Auth Type
+3. Use `{{username}}` and `{{token}}` in the username and password field respectively. This uses the variables in your environment
+4. In the `Query` tab, you will be able to import your schema, add your query and the relevant variables
+
+# Testing Queries
+1. In the `Query` tab, the arguments used for the select query can be changed in the `Variables` section.
+1. Click on the `Query` button
+1. You should see the response from the query from the `Response` section

--- a/dg/index.md
+++ b/dg/index.md
@@ -25,6 +25,8 @@ If you are a new developer, you'll find it useful to read the first few sections
 
 1. **The [_Testing_](testing.md) page** explains how WATcher is being tested.
 
-1. **The [_Project management_](project-management.md) page** has information on project management activities to be done by senior members of the dev team.
+1. **The [_API testing_](api-testing.md) page** explains how Postman is being used to test and create new queries.
 
-1. **The [_Future directions_](future-directions.md) page** lists some ideas for improving WATcher in the future.
+2. **The [_Project management_](project-management.md) page** has information on project management activities to be done by senior members of the dev team.
+
+3. **The [_Future directions_](future-directions.md) page** lists some ideas for improving WATcher in the future.

--- a/dg/tools.md
+++ b/dg/tools.md
@@ -81,3 +81,11 @@ The sequence diagram below shows the OAuth flow for the WATcher web app.
 ## Testing tools
 
 Described in the [Testing](testing.md) page.
+
+-------------------------------------------------------------------
+
+## Postman
+
+Postman is an API development tool that allows developers to design, test and debug APIs.
+
+More information can be found in the [API Testing](api-testing.md) page.


### PR DESCRIPTION
### Summary:
Fixes #19

### Changes Made:
* Added Postman as a tool used
* Include documentation API testing using Postman

### Proposed Commit Message:
```
Add Postman documentation for API testing

WATcher relies on GraphQL for various queries from GitHub. To
streamline development, it's essential to have a dedicated tool for
viewing, testing, and creating queries efficiently.

Instead of debugging through the network tab or manually writing and
running queries in code—both of which can be cumbersome—Postman
provides an intuitive interface for API exploration. By setting up a
sandbox environment with clear documentation, we can:

* Simplify debugging and testing
* Encourage contributions from new developers leveraging the
GitHub API

Let's set up a dedicated sandbox for API testing using Postman. 
```
